### PR TITLE
Include all fields in the useAuthInfo hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/PropelAuth/react"
   },
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "keywords": [
     "auth",

--- a/src/useAuthInfo.ts
+++ b/src/useAuthInfo.ts
@@ -4,6 +4,11 @@ import { AuthContext } from "./AuthContext"
 
 export type UseAuthInfoLoading = {
     loading: true
+    isLoggedIn: undefined
+    accessToken: undefined
+    user: undefined
+    orgHelper: undefined
+    accessHelper: undefined
 }
 
 export type UseAuthInfoLoggedInProps = {
@@ -36,6 +41,11 @@ export function useAuthInfo(): UseAuthInfoProps {
     if (loading) {
         return {
             loading: true,
+            isLoggedIn: undefined,
+            accessToken: undefined,
+            orgHelper: undefined,
+            accessHelper: undefined,
+            user: undefined,
         }
     } else if (authInfo && authInfo.accessToken) {
         return {


### PR DESCRIPTION
We were previously requiring that people check `loading` before they could get any of the other fields.
This was nice because it forces you to check loading before you can accidentally check isLoggedIn.

The downside is you can't destructure, like:
const {loading, isLoggedIn} = useAuthInfo()

so this fixes that