### PR TITLE
Add a useClient composition

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
     createClient,
     RedirectToLoginOptions,
     RedirectToSignupOptions,
+    IAuthClient,
 } from "@propelauth/javascript"
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from "react"
 import { loadOrgSelectionFromLocalStorage } from "./useActiveOrg"
@@ -11,6 +12,7 @@ import { withRequiredAuthInfo } from "./withRequiredAuthInfo"
 interface InternalAuthState {
     loading: boolean
     authInfo: AuthenticationInfo | null
+    client: IAuthClient
 
     logout: (redirectOnLogout: boolean) => Promise<void>
 
@@ -168,6 +170,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
     const value = {
         loading: authInfoState.loading,
         authInfo: authInfoState.authInfo,
+        client,
         logout,
         redirectToLoginPage,
         redirectToSignupPage,

--- a/src/useClient.tsx
+++ b/src/useClient.tsx
@@ -1,0 +1,10 @@
+import { useContext } from "react"
+import { AuthContext } from "./AuthContext"
+
+export function useClient() {
+    const context = useContext(AuthContext)
+    if (context === undefined) {
+        throw new Error("useClient must be used within an AuthProvider or RequiredAuthProvider")
+    }
+    return context.client;
+}


### PR DESCRIPTION
Sets up a `useClient` composition for direct access to functions exposed in `createClient` from `@propelauth/javascript` (https://github.com/PropelAuth/react/issues/32)