### PR TITLE
[TIC-14] Fix unnecessary rendering of `RequiredAuthProvider`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ cmake-build-*/
 # IntelliJ
 out/
 
+# VS Code
+.vscode
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
 } from "@propelauth/javascript"
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from "react"
 import { loadOrgSelectionFromLocalStorage } from "./useActiveOrg"
+import { WithLoggedInAuthInfoProps } from "./withAuthInfo"
 import { withRequiredAuthInfo } from "./withRequiredAuthInfo"
 
 interface InternalAuthState {
@@ -31,10 +32,14 @@ interface InternalAuthState {
     activeOrgFn: () => string | null
 
     refreshAuthInfo: () => Promise<void>
+    displayWhileLoading?: React.ReactElement
+    displayIfLoggedOut?: React.ReactElement
 }
 
 export type AuthProviderProps = {
     authUrl: string
+    displayWhileLoading?: React.ReactElement
+    displayIfLoggedOut?: React.ReactElement
     getActiveOrgFn?: () => string | null
     children?: React.ReactNode
 }
@@ -165,10 +170,14 @@ export const AuthProvider = (props: AuthProviderProps) => {
     }, [dispatch])
 
     const activeOrgFn = props.getActiveOrgFn || loadOrgSelectionFromLocalStorage
+    const displayWhileLoading = props.displayWhileLoading
+    const displayIfLoggedOut = props.displayIfLoggedOut
     const value = {
         loading: authInfoState.loading,
         authInfo: authInfoState.authInfo,
         logout,
+        displayWhileLoading,
+        displayIfLoggedOut,
         redirectToLoginPage,
         redirectToSignupPage,
         redirectToAccountPage,
@@ -187,20 +196,16 @@ export const AuthProvider = (props: AuthProviderProps) => {
     return <AuthContext.Provider value={value}>{props.children}</AuthContext.Provider>
 }
 
+const RequiredAuthWrappedComponent = withRequiredAuthInfo(
+    ({ children }: { children: React.ReactNode } & WithLoggedInAuthInfoProps) => <>{children}</>
+)
+
 export const RequiredAuthProvider = (props: RequiredAuthProviderProps) => {
-    const { children, displayIfLoggedOut, displayWhileLoading, ...sharedProps } = props
-    const WrappedComponent = withRequiredAuthInfo(
-        () => {
-            return <React.Fragment>{children}</React.Fragment>
-        },
-        {
-            displayWhileLoading: displayWhileLoading,
-            displayIfLoggedOut: displayIfLoggedOut,
-        }
-    )
+    const { children, ...sharedProps } = props
+
     return (
         <AuthProvider {...sharedProps}>
-            <WrappedComponent />
+            <RequiredAuthWrappedComponent>{children}</RequiredAuthWrappedComponent>
         </AuthProvider>
     )
 }

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -32,14 +32,14 @@ interface InternalAuthState {
     activeOrgFn: () => string | null
 
     refreshAuthInfo: () => Promise<void>
-    displayWhileLoading?: React.ReactElement
-    displayIfLoggedOut?: React.ReactElement
+    defaultDisplayWhileLoading?: React.ReactElement
+    defaultDisplayIfLoggedOut?: React.ReactElement
 }
 
 export type AuthProviderProps = {
     authUrl: string
-    displayWhileLoading?: React.ReactElement
-    displayIfLoggedOut?: React.ReactElement
+    defaultDisplayWhileLoading?: React.ReactElement
+    defaultDisplayIfLoggedOut?: React.ReactElement
     getActiveOrgFn?: () => string | null
     children?: React.ReactNode
 }
@@ -170,14 +170,14 @@ export const AuthProvider = (props: AuthProviderProps) => {
     }, [dispatch])
 
     const activeOrgFn = props.getActiveOrgFn || loadOrgSelectionFromLocalStorage
-    const displayWhileLoading = props.displayWhileLoading
-    const displayIfLoggedOut = props.displayIfLoggedOut
+
+    const { defaultDisplayWhileLoading, defaultDisplayIfLoggedOut } = props
     const value = {
         loading: authInfoState.loading,
         authInfo: authInfoState.authInfo,
         logout,
-        displayWhileLoading,
-        displayIfLoggedOut,
+        defaultDisplayWhileLoading,
+        defaultDisplayIfLoggedOut,
         redirectToLoginPage,
         redirectToSignupPage,
         redirectToAccountPage,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -197,7 +197,7 @@ it("RequiredAuthProvider displays logged out value if logged out", async () => {
     expectCreateClientWasCalledCorrectly()
 })
 
-it("withRequiredAuthInfo displays logged out value if logged out", async () => {
+it("withRequiredAuthInfo displays logged out value if logged out from args", async () => {
     mockClient.getAuthenticationInfoOrNull.mockReturnValue(null)
 
     const ErrorComponent = () => {
@@ -217,6 +217,54 @@ it("withRequiredAuthInfo displays logged out value if logged out", async () => {
     )
 
     await waitFor(() => screen.getByText("Finished"))
+    expectCreateClientWasCalledCorrectly()
+})
+
+it("withRequiredAuthInfo displays logged out value if logged out from context", async () => {
+    mockClient.getAuthenticationInfoOrNull.mockReturnValue(null)
+
+    const ErrorComponent = () => {
+        return <div>Error</div>
+    }
+    const SuccessComponent = () => {
+        return <div>Finished</div>
+    }
+
+    const WrappedComponent = withRequiredAuthInfo(ErrorComponent)
+    render(
+        <AuthProvider authUrl={AUTH_URL} displayIfLoggedOut={<SuccessComponent />}>
+            <WrappedComponent />
+        </AuthProvider>
+    )
+
+    await waitFor(() => screen.getByText("Finished"))
+    expectCreateClientWasCalledCorrectly()
+})
+
+it("withRequiredAuthInfo displays logged out value from args if logged out from both args and context", async () => {
+    mockClient.getAuthenticationInfoOrNull.mockReturnValue(null)
+
+    const ErrorComponent = () => {
+        return <div>Error</div>
+    }
+    const SuccessArgComponent = () => {
+        return <div>Finished from Args</div>
+    }
+
+    const SuccessContextComponent = () => {
+        return <div>Finished from Context</div>
+    }
+
+    const WrappedComponent = withRequiredAuthInfo(ErrorComponent, {
+        displayIfLoggedOut: <SuccessArgComponent />,
+    })
+    render(
+        <AuthProvider authUrl={AUTH_URL} displayIfLoggedOut={<SuccessContextComponent />}>
+            <WrappedComponent />
+        </AuthProvider>
+    )
+
+    await waitFor(() => screen.getByText("Finished from Args"))
     expectCreateClientWasCalledCorrectly()
 })
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -441,7 +441,7 @@ it("when client logs out, authInfo is refreshed", async () => {
     expect(finalProps.isLoggedIn).toBe(false)
 })
 
-it("withAuthInfo renders loading correctly", async () => {
+it("withAuthInfo renders loading correctly from args", async () => {
     const authInfo = createAuthenticationInfo()
     const Loading = () => <div>Loading</div>
     const Component = (props) => <div>Finished</div>
@@ -462,6 +462,57 @@ it("withAuthInfo renders loading correctly", async () => {
     await waitFor(() => screen.getByText("Loading"))
     jest.advanceTimersByTime(50)
     await waitFor(() => screen.getByText("Loading"))
+    jest.advanceTimersByTime(50)
+    await waitFor(() => screen.getByText("Finished"))
+})
+
+it("withAuthInfo renders loading correctly from context", async () => {
+    const authInfo = createAuthenticationInfo()
+    const Loading = () => <div>Loading</div>
+    const Component = (props) => <div>Finished</div>
+    const WrappedComponent = withAuthInfo(Component)
+
+    // Wait 100ms to return authInfo to force loading to be displayed
+    mockClient.getAuthenticationInfoOrNull.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(authInfo), 100))
+    )
+
+    render(
+        <AuthProvider authUrl={AUTH_URL} defaultDisplayWhileLoading={<Loading />}>
+            <WrappedComponent />
+        </AuthProvider>
+    )
+
+    // Loading is displayed until 100ms passes
+    await waitFor(() => screen.getByText("Loading"))
+    jest.advanceTimersByTime(50)
+    await waitFor(() => screen.getByText("Loading"))
+    jest.advanceTimersByTime(50)
+    await waitFor(() => screen.getByText("Finished"))
+})
+
+it("withAuthInfo renders loading correctly from args, overriding context", async () => {
+    const authInfo = createAuthenticationInfo()
+    const LoadingFromArg = () => <div>Loading From Arg</div>
+    const LoadingFromContext = () => <div>Loading From Context</div>
+    const Component = (props) => <div>Finished</div>
+    const WrappedComponent = withAuthInfo(Component, { displayWhileLoading: <LoadingFromArg /> })
+
+    // Wait 100ms to return authInfo to force loading to be displayed
+    mockClient.getAuthenticationInfoOrNull.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(authInfo), 100))
+    )
+
+    render(
+        <AuthProvider authUrl={AUTH_URL} defaultDisplayWhileLoading={<LoadingFromContext />}>
+            <WrappedComponent />
+        </AuthProvider>
+    )
+
+    // Loading is displayed until 100ms passes
+    await waitFor(() => screen.getByText("Loading From Arg"))
+    jest.advanceTimersByTime(50)
+    await waitFor(() => screen.getByText("Loading From Arg"))
     jest.advanceTimersByTime(50)
     await waitFor(() => screen.getByText("Finished"))
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -188,7 +188,7 @@ it("RequiredAuthProvider displays logged out value if logged out", async () => {
 
     const WrappedComponent = withAuthInfo(ErrorComponent)
     render(
-        <RequiredAuthProvider authUrl={AUTH_URL} displayIfLoggedOut={<SuccessComponent />}>
+        <RequiredAuthProvider authUrl={AUTH_URL} defaultDisplayIfLoggedOut={<SuccessComponent />}>
             <WrappedComponent />
         </RequiredAuthProvider>
     )
@@ -232,7 +232,7 @@ it("withRequiredAuthInfo displays logged out value if logged out from context", 
 
     const WrappedComponent = withRequiredAuthInfo(ErrorComponent)
     render(
-        <AuthProvider authUrl={AUTH_URL} displayIfLoggedOut={<SuccessComponent />}>
+        <AuthProvider authUrl={AUTH_URL} defaultDisplayIfLoggedOut={<SuccessComponent />}>
             <WrappedComponent />
         </AuthProvider>
     )

--- a/src/withAuthInfo.tsx
+++ b/src/withAuthInfo.tsx
@@ -44,15 +44,17 @@ export function withAuthInfo<P extends WithAuthInfoProps>(
             throw new Error("withAuthInfo must be used within an AuthProvider or RequiredAuthProvider")
         }
 
+        const { loading, authInfo, defaultDisplayWhileLoading, refreshAuthInfo } = context
+
         function displayLoading() {
-            if (args && args.displayWhileLoading) {
+            if (args?.displayWhileLoading) {
                 return args.displayWhileLoading
-            } else {
-                return <React.Fragment />
+            } else if (defaultDisplayWhileLoading) {
+                return defaultDisplayWhileLoading
             }
+            return <React.Fragment />
         }
 
-        const { loading, authInfo, refreshAuthInfo } = context
         if (loading) {
             return displayLoading()
         } else if (authInfo) {

--- a/src/withRequiredAuthInfo.tsx
+++ b/src/withRequiredAuthInfo.tsx
@@ -22,13 +22,13 @@ export function withRequiredAuthInfo<P extends WithLoggedInAuthInfoProps>(
             throw new Error("withRequiredAuthInfo must be used within an AuthProvider or RequiredAuthProvider")
         }
 
-        const { loading, authInfo, displayWhileLoading, displayIfLoggedOut, refreshAuthInfo } = context
+        const { loading, authInfo, defaultDisplayIfLoggedOut, defaultDisplayWhileLoading, refreshAuthInfo } = context
 
         function displayLoading() {
             if (args && args.displayWhileLoading) {
                 return args.displayWhileLoading
-            } else if (displayWhileLoading) {
-                return displayWhileLoading
+            } else if (defaultDisplayWhileLoading) {
+                return defaultDisplayWhileLoading
             }
             return <React.Fragment />
         }
@@ -36,8 +36,8 @@ export function withRequiredAuthInfo<P extends WithLoggedInAuthInfoProps>(
         function displayLoggedOut() {
             if (args && args.displayIfLoggedOut) {
                 return args.displayIfLoggedOut
-            } else if (displayIfLoggedOut) {
-                return displayIfLoggedOut
+            } else if (defaultDisplayIfLoggedOut) {
+                return defaultDisplayIfLoggedOut
             }
             return <RedirectToLogin />
         }

--- a/src/withRequiredAuthInfo.tsx
+++ b/src/withRequiredAuthInfo.tsx
@@ -22,23 +22,26 @@ export function withRequiredAuthInfo<P extends WithLoggedInAuthInfoProps>(
             throw new Error("withRequiredAuthInfo must be used within an AuthProvider or RequiredAuthProvider")
         }
 
+        const { loading, authInfo, displayWhileLoading, displayIfLoggedOut, refreshAuthInfo } = context
+
         function displayLoading() {
             if (args && args.displayWhileLoading) {
                 return args.displayWhileLoading
-            } else {
-                return <React.Fragment />
+            } else if (displayWhileLoading) {
+                return displayWhileLoading
             }
+            return <React.Fragment />
         }
 
         function displayLoggedOut() {
             if (args && args.displayIfLoggedOut) {
                 return args.displayIfLoggedOut
-            } else {
-                return <RedirectToLogin />
+            } else if (displayIfLoggedOut) {
+                return displayIfLoggedOut
             }
+            return <RedirectToLogin />
         }
 
-        const { loading, authInfo, refreshAuthInfo } = context
         if (loading) {
             return displayLoading()
         } else if (authInfo) {

--- a/src/withRequiredAuthInfo.tsx
+++ b/src/withRequiredAuthInfo.tsx
@@ -25,7 +25,7 @@ export function withRequiredAuthInfo<P extends WithLoggedInAuthInfoProps>(
         const { loading, authInfo, defaultDisplayIfLoggedOut, defaultDisplayWhileLoading, refreshAuthInfo } = context
 
         function displayLoading() {
-            if (args && args.displayWhileLoading) {
+            if (args?.displayWhileLoading) {
                 return args.displayWhileLoading
             } else if (defaultDisplayWhileLoading) {
                 return defaultDisplayWhileLoading
@@ -34,7 +34,7 @@ export function withRequiredAuthInfo<P extends WithLoggedInAuthInfoProps>(
         }
 
         function displayLoggedOut() {
-            if (args && args.displayIfLoggedOut) {
+            if (args?.displayIfLoggedOut) {
                 return args.displayIfLoggedOut
             } else if (defaultDisplayIfLoggedOut) {
                 return defaultDisplayIfLoggedOut


### PR DESCRIPTION
# Background
When rendering the `RequiredAuthProvider`, there were unnecessary renders whenever a child component was rendering. Typically, this behavior should not effect a parent component, especially if none of the props/context values have changed. However, as seen in [this example project](https://github.com/Teddarific/propel-auth-example), the rendering happened on each re-render of a child component. 

# The Issue
As standard React practices go, it is very important to avoid [declaring and initializing React components inside of other components](https://levelup.gitconnected.com/code-review-avoid-declaring-react-component-inside-parent-component-1768a645f523), as each time the parent is rendered, all of its components inside will be redeclared. This causes bugs with the React lifecycle for the nested component and the outer component, even if there are no render-related changes. This change can actually be seen in this code, as provided to show a workaround for teh `RequiredAuthProvider`, but with a caveat:

```ts
export default function App({Component, pageProps}: AppProps) {
    return (
        <AuthProvider
            authUrl={
                process.env.NEXT_PUBLIC_AUTH_URL ?? ""
            }
        >
            <RequireAuth>
                <Wrapper>
                    <Component {...pageProps} />
                </Wrapper>
            </RequireAuth>
        </AuthProvider>
    );
}

type RequireAuthProps = {
    children: React.ReactNode
} & WithLoggedInAuthInfoProps

const RequireAuth = withRequiredAuthInfo(({children}: RequireAuthProps) => {
    return <>{children}</>
})
```

As seen here, there are no nested components, **but** there is no capabilities for the `displayWhileLoading` or `displayIfLoggedOut` props. 

# The Solution
Since we still need the `displayWhileLoading` and `displayIfLoggedOut` props for the provider, we instead need to add it to the context of the `AuthProvider`. This way, we can avoid nesting a component while having these values. As such, the values will be useless unless used with `withRequiredAuthInfo`, as this function accounts for them. They can now be passed as props to the `RequiredAuthProvider` without any component nesting. Tests have been added to display the behavior of this new flow.