### PR TITLE
[HOTFIx] Fix props for default and passed props for `RequiredAuthProvider`

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -44,7 +44,8 @@ export type AuthProviderProps = {
     children?: React.ReactNode
 }
 
-export interface RequiredAuthProviderProps extends AuthProviderProps {
+export interface RequiredAuthProviderProps
+    extends Omit<AuthProviderProps, "defaultDisplayWhileLoading" | "defaultDisplayIfLoggedOut"> {
     displayWhileLoading?: React.ReactElement
     displayIfLoggedOut?: React.ReactElement
 }
@@ -201,10 +202,14 @@ const RequiredAuthWrappedComponent = withRequiredAuthInfo(
 )
 
 export const RequiredAuthProvider = (props: RequiredAuthProviderProps) => {
-    const { children, ...sharedProps } = props
+    const { children, displayIfLoggedOut, displayWhileLoading, ...sharedProps } = props
 
     return (
-        <AuthProvider {...sharedProps}>
+        <AuthProvider
+            {...sharedProps}
+            defaultDisplayIfLoggedOut={displayIfLoggedOut}
+            defaultDisplayWhileLoading={displayWhileLoading}
+        >
             <RequiredAuthWrappedComponent>{children}</RequiredAuthWrappedComponent>
         </AuthProvider>
     )

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -188,7 +188,7 @@ it("RequiredAuthProvider displays logged out value if logged out", async () => {
 
     const WrappedComponent = withAuthInfo(ErrorComponent)
     render(
-        <RequiredAuthProvider authUrl={AUTH_URL} defaultDisplayIfLoggedOut={<SuccessComponent />}>
+        <RequiredAuthProvider authUrl={AUTH_URL} displayIfLoggedOut={<SuccessComponent />}>
             <WrappedComponent />
         </RequiredAuthProvider>
     )


### PR DESCRIPTION
When passing in a standard `displayWhileLoading` or `displayIfLoggedOut` prop to the `RequiredAuthProvider`, the prop was being disregarded in the context due to checking the `defaultDisplay...` params. This fixes this so both props for default and normal props are not allowed, as would be expected.