### PR TITLE
[FEAT] `getAccessToken` 

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -14,6 +14,7 @@ import { useClientRef, useClientRefCallback } from "./useClientRef"
 
 export interface Tokens {
     getAccessTokenForOrg: (orgId: string) => Promise<AccessTokenForActiveOrg>
+    getAccessToken: () => Promise<string | undefined>
 }
 
 export interface InternalAuthState {
@@ -149,6 +150,12 @@ export const AuthProvider = (props: AuthProviderProps) => {
     const getSetupSAMLPageUrl = useClientRefCallback(clientRef, (client) => client.getSetupSAMLPageUrl)
 
     const getAccessTokenForOrg = useClientRefCallback(clientRef, (client) => client.getAccessTokenForOrg)
+    const getAccessToken = useClientRefCallback(clientRef, (client) => {
+        return async () => {
+            const authInfo = await client.getAuthenticationInfoOrNull()
+            return authInfo?.accessToken
+        }
+    })
 
     const refreshAuthInfo = useCallback(async () => {
         if (clientRef.current === null) {
@@ -186,6 +193,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
         refreshAuthInfo,
         tokens: {
             getAccessTokenForOrg,
+            getAccessToken,
         },
     }
     return <AuthContext.Provider value={value}>{props.children}</AuthContext.Provider>

--- a/src/AuthContextForTesting.tsx
+++ b/src/AuthContextForTesting.tsx
@@ -63,6 +63,7 @@ export const AuthProviderForTesting = ({
                     error: undefined,
                     accessToken: "ACCESS_TOKEN",
                 }),
+            getAccessToken: () => Promise.resolve("ACCESS_TOKEN"),
         },
     }
 

--- a/src/withAuthInfo.tsx
+++ b/src/withAuthInfo.tsx
@@ -7,6 +7,7 @@ import { AuthContext, Tokens } from "./AuthContext"
 export type WithLoggedInAuthInfoProps = {
     isLoggedIn: true
     accessToken: string
+    getAccessToken: () => Promise<string>
     user: User
     userClass: UserClass
     orgHelper: OrgHelper
@@ -21,6 +22,7 @@ export type WithLoggedInAuthInfoProps = {
 export type WithNotLoggedInAuthInfoProps = {
     isLoggedIn: false
     accessToken: null
+    getAccessToken: () => Promise<undefined>
     user: null
     userClass: null
     orgHelper: null
@@ -67,6 +69,7 @@ export function withAuthInfo<P extends WithAuthInfoProps>(
             const loggedInProps: P = {
                 ...(props as P),
                 accessToken: authInfo.accessToken,
+                getAccessToken: tokens.getAccessToken,
                 isLoggedIn: !!authInfo.accessToken,
                 orgHelper: authInfo.orgHelper,
                 accessHelper: authInfo.accessHelper,
@@ -83,6 +86,7 @@ export function withAuthInfo<P extends WithAuthInfoProps>(
             const notLoggedInProps: P = {
                 ...(props as P),
                 accessToken: null,
+                getAccessToken: () => undefined,
                 isLoggedIn: false,
                 user: null,
                 userClass: null,

--- a/src/withRequiredAuthInfo.tsx
+++ b/src/withRequiredAuthInfo.tsx
@@ -49,6 +49,7 @@ export function withRequiredAuthInfo<P extends WithLoggedInAuthInfoProps>(
             const loggedInProps: P = {
                 ...(props as P),
                 accessToken: authInfo.accessToken,
+                getAccessToken: tokens.getAccessToken,
                 isLoggedIn: !!authInfo.accessToken,
                 orgHelper: authInfo.orgHelper,
                 accessHelper: authInfo.accessHelper,


### PR DESCRIPTION
# Background
This PR adds a new function to the auth context, `getAccessToken()`. This allows for a specific call to get the latest valid access token. This can help with avoiding bugs where we closed in a local usage of the out of date access token, and now we can explicitly get the newest one every time. 

## Smoke Testing

* In the dashboard, where the env. config bug would happen, this function was used, and solved the issue of saving the access token in a use ref. 
* In an example app, this function was used and called in a `useEffect` with a `useState` saving the access token. 