### PR TITLE
fix(auth-info): autoInfo now updates when the authInfo is originally falsy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/react"
     },
-    "version": "2.0.28",
+    "version": "2.0.29",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -91,7 +91,7 @@ function authInfoStateReducer(_state: AuthInfoState, action: AuthInfoStateAction
             loading: false,
             authInfo: action.authInfo,
         }
-    } else if (_state.authInfo && _state.authInfo.accessToken !== action.authInfo.accessToken) {
+    } else if (_state?.authInfo?.accessToken !== action.authInfo?.accessToken) {
         return {
             loading: false,
             authInfo: action.authInfo,


### PR DESCRIPTION
# Description

In scenarios where the user starts off as logged out, and attempts to refresh the auth info manually, no changes to the store state will take place because `_state.authInfo` will already be `null` and will cause the check to fail.

This particular scenario occurs when leveraging the new [ui based hooks](https://ui.propelauth.com/login-signup-apis#login-state). It goes as follows:

1. User is not logged in
2. User logs in successfully using the `emailPasswordLogin` call from `useAuthFrontendApis`.
3. The `refreshAuthInfo` function from `useAuthInfo` is manually executed
4. `user` & `accessToken` remain as `null`, even though the login flow has completed, and regardless if calls to the `/refresh_token` endpoint succeeed

**Context:** This happens because the flow that I'm currently trying to implement involves keeping the user on the root route before redirecting them to a new page, as there is some basic user-related information we'd like to show before redirecting.

I understand this check was originally put in place in [this commit](https://github.com/ealmeid/react/commit/51fc901ff2ddcad449f8861a360939ee008ddc9e), but to compensate for it, optional chaining is put on both the `_state` & `authInfo` objects.
